### PR TITLE
Use `ViewSequence` and refactor otherwise

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -50,9 +50,9 @@ fn app_logic(state: &mut AppState) -> impl Element<AppState> {
                     };
                 }),
         )),
-        map(vec![tile_layer(
+        map(tile_layer(
             "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        )])
+        ))
         .zoom(state.zoom)
         .center(state.center.0, state.center.1), // TODO .on_zoom(|state, zoom|{ })
     ))

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -1,23 +1,46 @@
 use std::marker::PhantomData;
 
 use wasm_bindgen_futures::spawn_local;
-use web_sys::wasm_bindgen::JsCast;
+use web_sys::wasm_bindgen::UnwrapThrowExt;
 use xilem_web::{
-    core::{MessageResult, Mut, View, ViewId, ViewMarker},
-    DomNode, DynMessage, ElementProps, Pod, ViewCtx, WithStyle, HTML_NS,
+    core::{
+        AppendVec, ElementSplice, MessageResult, Mut, SuperElement, View, ViewElement, ViewId,
+        ViewMarker, ViewPathTracker, ViewSequence,
+    },
+    elements::html,
+    interfaces::HtmlElement,
+    style, DynMessage, Style, ViewCtx,
 };
 
 mod events;
 pub use self::events::*;
 
-// TODO:
-// How can we pass tuples, like `()`, `(C)`, `(C, C)`?
-pub fn map<State, Action, C>(children: Vec<C>) -> Map<State, Action, C>
+// I think Action could probably be used to signify `Map` some changes, it could match
+
+pub enum MapAction {}
+
+pub trait MapChildren<State>:
+    ViewSequence<State, MapAction, ViewCtx, MapChildElement, MapMessage>
+{
+}
+
+impl<V, State> MapChildren<State> for V where
+    V: ViewSequence<State, MapAction, ViewCtx, MapChildElement, MapMessage>
+{
+}
+
+type MapDomView<T, A> = Style<html::Div<T, A>, T, A>;
+
+pub fn map<State, Action, Children>(children: Children) -> Map<State, Action, Children>
 where
-    C: MapChild<State, Action>,
-    C::ViewState: MapChildViewState,
+    State: 'static,
+    Action: 'static,
+    Children: MapChildren<State>,
 {
     Map {
+        // A Frozen view would be even better (perf), but that basically requires TAITs
+        // alternatively the view could be created in `View::build` as well (and stored in `View::State`)
+        map_view: html::div(()).style([style("width", "100%"), style("height", "100%")]),
         zoom: None,
         center: None,
         children,
@@ -25,11 +48,61 @@ where
     }
 }
 
+// TODO make this actually useful with element state
+pub struct MapChildElement;
+
+impl ViewElement for MapChildElement {
+    type Mut<'a> = &'a mut MapChildElement;
+}
+
+// Necessary for the `ViewSequence`
+// This could theoretically cast more specific elements into a (type-erased) `AnyMapChildElement` if necessary.
+impl SuperElement<MapChildElement> for MapChildElement {
+    fn upcast(child: MapChildElement) -> Self {
+        child
+    }
+
+    fn with_downcast_val<R>(
+        this: Mut<'_, Self>,
+        f: impl FnOnce(Mut<'_, MapChildElement>) -> R,
+    ) -> (Self::Mut<'_>, R) {
+        let r = f(this);
+        (this, r)
+    }
+}
+
+struct MapChildrenSplice;
+
+/// Hmm I wonder if we could provide some generic types for this, to make this simpler,
+/// we could e.g. export `VecSplice` from xilem_web (again),
+/// and implement that trait for `VecSplice`, when it's just necessary to maintain a Vec of elements...
+impl ElementSplice<MapChildElement> for MapChildrenSplice {
+    fn with_scratch<R>(&mut self, f: impl FnOnce(&mut AppendVec<MapChildElement>) -> R) -> R {
+        f(&mut AppendVec::default())
+    }
+
+    fn insert(&mut self, _element: MapChildElement) {}
+
+    fn mutate<R>(&mut self, f: impl FnOnce(Mut<'_, MapChildElement>) -> R) -> R {
+        f(&mut MapChildElement)
+    }
+
+    fn skip(&mut self, _n: usize) {}
+
+    fn delete<R>(&mut self, f: impl FnOnce(Mut<'_, MapChildElement>) -> R) -> R {
+        f(&mut MapChildElement)
+    }
+}
+
 /// This is a marker trait that is used to pass only map-specific children
 /// to the [`map`] function.
-pub trait MapChild<State, Action>: View<State, Action, ViewCtx, DynMessage>
-where
-    Self::ViewState: MapChildViewState,
+pub trait MapChild<State, Action>:
+    View<State, Action, ViewCtx, MapMessage, Element = MapChildElement>
+{
+}
+
+impl<V, State, Action> MapChild<State, Action> for V where
+    V: View<State, Action, ViewCtx, MapMessage, Element = MapChildElement>
 {
 }
 
@@ -40,22 +113,15 @@ pub trait MapChildViewState {
     fn after_rebuild(&mut self, map: &leaflet::Map);
 }
 
-pub struct Map<State, Action, C>
-where
-    C: MapChild<State, Action>,
-    C::ViewState: MapChildViewState,
-{
-    children: Vec<C>,
+pub struct Map<State, Action, Children> {
+    map_view: MapDomView<State, Action>,
+    children: Children,
     zoom: Option<f64>,
     center: Option<(f64, f64)>,
     phantom: PhantomData<fn() -> (State, Action)>,
 }
 
-impl<State, Action, C> Map<State, Action, C>
-where
-    C: MapChild<State, Action>,
-    C::ViewState: MapChildViewState,
-{
+impl<State, Action, Children> Map<State, Action, Children> {
     pub fn zoom(mut self, value: f64) -> Self {
         self.zoom = Some(value);
         self
@@ -74,116 +140,128 @@ where
     }
 }
 
-impl<State, Action, C> ViewMarker for Map<State, Action, C>
-where
-    C: MapChild<State, Action>,
-    C::ViewState: MapChildViewState,
-{
-}
+impl<State, Action, Children> ViewMarker for Map<State, Action, Children> {}
 
-pub struct MapViewState<State, Action, C>
-where
-    C: MapChild<State, Action>,
-    C::ViewState: MapChildViewState,
-{
+pub struct MapViewState<DS, CS> {
+    map_dom_state: DS,
+    children_state: CS,
     leaflet_map: leaflet::Map,
-    children: Vec<(C::Element, C::ViewState)>,
 }
 
-#[derive(Debug)]
-enum MapMessage {
+#[derive(Debug, Clone, Copy)]
+pub enum MapMessage {
     InitMap,
 }
 
-impl<State, Action, C> View<State, Action, ViewCtx, DynMessage> for Map<State, Action, C>
+/// Distinctive id for better debugging
+const MAP_VIEW_ID: ViewId = ViewId::new(1236068);
+
+impl<State, Action, Children> View<State, Action, ViewCtx, DynMessage>
+    for Map<State, Action, Children>
 where
     State: 'static,
     Action: 'static,
-    C: MapChild<State, Action>,
-    C::ViewState: MapChildViewState,
+    Children: MapChildren<State>,
 {
-    type Element = Pod<web_sys::HtmlElement, ElementProps>;
+    type Element = <MapDomView<State, Action> as View<State, Action, ViewCtx, DynMessage>>::Element;
 
-    type ViewState = MapViewState<State, Action, C>;
+    type ViewState = MapViewState<
+        <MapDomView<State, Action> as View<State, Action, ViewCtx, DynMessage>>::ViewState,
+        Children::SeqState,
+    >;
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        // TODO:
-        // Is there a way to just use `html::div(())`?
-        let mut pod = Pod::new_element(vec![], HTML_NS, "div");
-        pod.props
-            .styles()
-            .set_style("width".into(), Some("100%".into()));
-        pod.props
-            .styles()
-            .set_style("height".into(), Some("100%".into()));
-        pod.node.apply_props(&mut pod.props);
+        ctx.with_id(MAP_VIEW_ID, |ctx| {
+            let (map_dom_element, map_dom_state) = self.map_view.build(ctx);
 
-        let map_options = leaflet::MapOptions::default();
-        let html_el = pod.node.unchecked_ref::<web_sys::HtmlElement>();
-        let leaflet_map = leaflet::Map::new_with_element(html_el, &map_options);
+            let map_options = leaflet::MapOptions::default();
+            let leaflet_map = leaflet::Map::new_with_element(&map_dom_element.node, &map_options);
 
-        let children = self
-            .children
-            .iter()
-            .map(|c| c.build(ctx))
-            .collect::<Vec<_>>();
+            let mut elements = AppendVec::default();
+            let children_state = self.children.seq_build(ctx, &mut elements);
 
-        let view_state = MapViewState {
-            leaflet_map,
-            children,
-        };
+            let view_state = MapViewState {
+                leaflet_map,
+                map_dom_state,
+                children_state,
+            };
 
-        // We have to postpone the map initiation
-        // because the DOM element has been created at this point in time
-        // but has not yet been mounted.
-        let thunk = ctx.message_thunk();
-        spawn_local(async move {
-            thunk.push_message(MapMessage::InitMap);
-        });
-        (pod.into(), view_state)
+            // Is the following an issue?
+            // Does it require on being in the DOM tree?
+            // Can the tile-layer be added before running `apply_zoom_and_center`?
+
+            // We have to postpone the map initiation
+            // because the DOM element has been created at this point in time
+            // but has not yet been mounted.
+            let thunk = ctx.message_thunk();
+            spawn_local(async move {
+                thunk.push_message(MapMessage::InitMap);
+            });
+            (map_dom_element, view_state)
+        })
     }
 
     fn rebuild<'el>(
         &self,
         prev: &Self,
         view_state: &mut Self::ViewState,
-        _: &mut ViewCtx,
+        ctx: &mut ViewCtx,
         element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
-        if prev.zoom != self.zoom || prev.center != self.center {
-            apply_zoom_and_center(&view_state.leaflet_map, self.zoom, self.center);
-        }
-        view_state
-            .children
-            .iter_mut()
-            .for_each(|(_, child_view_state): &mut (_, C::ViewState)| {
-                child_view_state.after_rebuild(&view_state.leaflet_map);
-            });
-        element
+        ctx.with_id(MAP_VIEW_ID, |ctx| {
+            let element =
+                self.map_view
+                    .rebuild(&prev.map_view, &mut view_state.map_dom_state, ctx, element);
+            if prev.zoom != self.zoom || prev.center != self.center {
+                apply_zoom_and_center(&view_state.leaflet_map, self.zoom, self.center);
+            }
+            let mut splice = MapChildrenSplice;
+            self.children.seq_rebuild(
+                &prev.children,
+                &mut view_state.children_state,
+                ctx,
+                &mut splice,
+            );
+            element
+        })
     }
 
-    fn teardown(&self, _: &mut Self::ViewState, _: &mut ViewCtx, _: Mut<Self::Element>) {
-        // TODO
+    fn teardown(&self, _: &mut Self::ViewState, ctx: &mut ViewCtx, _: Mut<Self::Element>) {
+        ctx.with_id(MAP_VIEW_ID, |_ctx| {
+            // TODO
+        });
     }
 
     fn message(
         &self,
         view_state: &mut Self::ViewState,
-        _: &[ViewId],
+        path: &[ViewId],
         message: DynMessage,
-        _: &mut State,
+        app_state: &mut State,
     ) -> MessageResult<Action, DynMessage> {
-        match *message.downcast().unwrap() {
+        let (first, rest) = path.split_first().unwrap_throw();
+        assert_eq!(*first, MAP_VIEW_ID);
+        let message = *message.downcast().unwrap();
+        match message {
+            // if the message itself is not for this view, it could just be redirected with the path to a child
             MapMessage::InitMap => {
                 apply_zoom_and_center(&view_state.leaflet_map, self.zoom, self.center);
-                view_state.children.iter_mut().for_each(
-                    |(_, child_view_state): &mut (_, C::ViewState)| {
-                        child_view_state.after_build(&view_state.leaflet_map);
-                    },
+                let children_message = self.children.seq_message(
+                    &mut view_state.children_state,
+                    rest,
+                    message,
+                    app_state,
                 );
+                match children_message {
+                    #[allow(unreachable_code)]
+                    // Could do something with the action message
+                    MessageResult::Action(action) => MessageResult::Action(match action {}),
+                    MessageResult::RequestRebuild => MessageResult::RequestRebuild,
+                    MessageResult::Nop => MessageResult::Nop,
+                    MessageResult::Stale(_) => MessageResult::Stale(Box::new(())),
+                }
             }
         }
-        MessageResult::Nop
     }
 }
 

--- a/src/tile_layer.rs
+++ b/src/tile_layer.rs
@@ -1,30 +1,23 @@
 use std::marker::PhantomData;
 
 use xilem_web::{
-    core::{MessageResult, Mut, NoElement, View, ViewId, ViewMarker},
-    DynMessage, ViewCtx,
+    core::{MessageResult, Mut, View, ViewId, ViewMarker},
+    ViewCtx,
 };
 
-use crate::{MapChild, MapChildViewState};
+use crate::{MapAction, MapChildElement, MapChildViewState, MapMessage};
 
-impl<State, Action> ViewMarker for TileLayer<State, Action> {}
-pub fn tile_layer<State, Action>(url_template: &'static str) -> TileLayer<State, Action> {
+impl<State> ViewMarker for TileLayer<State> {}
+pub fn tile_layer<State>(url_template: &'static str) -> TileLayer<State> {
     TileLayer {
         url_template,
         phantom: PhantomData,
     }
 }
 
-pub struct TileLayer<State, Action> {
+pub struct TileLayer<State> {
     url_template: &'static str,
-    phantom: PhantomData<fn() -> (State, Action)>,
-}
-
-impl<State, Action> MapChild<State, Action> for TileLayer<State, Action>
-where
-    State: 'static,
-    Action: 'static,
-{
+    phantom: PhantomData<fn() -> State>,
 }
 
 pub struct TileLayerViewState {
@@ -41,19 +34,15 @@ impl MapChildViewState for TileLayerViewState {
     }
 }
 
-impl<State, Action> View<State, Action, ViewCtx, DynMessage> for TileLayer<State, Action>
-where
-    State: 'static,
-    Action: 'static,
-{
-    type Element = NoElement;
+impl<State: 'static> View<State, MapAction, ViewCtx, MapMessage> for TileLayer<State> {
+    type Element = MapChildElement;
 
     type ViewState = TileLayerViewState;
 
     fn build(&self, _: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let tile_layer = leaflet::TileLayer::new(self.url_template);
         let view_state = TileLayerViewState { tile_layer };
-        (NoElement, view_state)
+        (MapChildElement, view_state)
     }
 
     fn rebuild<'el>(
@@ -77,9 +66,9 @@ where
         &self,
         _: &mut Self::ViewState,
         _: &[ViewId],
-        _: DynMessage,
+        _: MapMessage,
         _: &mut State,
-    ) -> MessageResult<Action, DynMessage> {
+    ) -> MessageResult<MapAction, MapMessage> {
         todo!()
     }
 }


### PR DESCRIPTION
I have not yet looked into the actual logic, but this is how it should probably be done, to be a little bit more extensible and idiomatic.

I would suggest looking into the different concepts of the traits, it's not the easiest to digest unfortunately though.

Implementing a custom derived `View` trait is more advanced territory, and likely not what an end-user should be doing usually.
I hope we can cover similar cases in the future with less boilerplate (keep in mind all of this is *very* experimental still)...