### PR TITLE
Cleanup a lot and correctly compose `ViewCtx` in `MapCtx` with `ViewCtx::as_owned`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ web-sys = "0.3.72"
 xilem_web = "0.1.0"
 
 [patch.crates-io.xilem_web]
-git = "https://github.com/linebender/xilem"
-rev = "f32277ab701d4259da6ac3cb85d6a7e5ab0f3e59"
+git = "https://github.com/Philipp-M/xilem"
+rev = "5cd6a4d59b0412e3ad96f3b59fdb789186314fed"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -17,7 +17,7 @@ impl Default for AppState {
             zoom_input: None,
             zoom: 12.0,
             center: (48.64, 9.46),
-            markers: Vec::new(),
+            markers: vec![(48.64, 9.46)],
         }
     }
 }
@@ -36,21 +36,14 @@ fn app_logic(state: &mut AppState) -> impl Element<AppState> {
             html::input(())
                 .attr("value", state.zoom)
                 .on_input(|state: &mut AppState, ev| {
-                    let Some(value) = input_event_target_value(&ev) else {
-                        return;
-                    };
-                    state.zoom_input = if !value.trim().is_empty() {
-                        Some(value)
-                    } else {
-                        None
-                    };
+                    state.zoom_input = input_event_target_value(&ev)
+                        .and_then(|value| (!value.trim().is_empty()).then_some(value));
                 })
                 .on_keyup(|state: &mut AppState, ev| {
                     if &*ev.key() == "Enter" {
-                        let Some(Ok(value)) = state.zoom_input.as_ref().map(|v| v.parse()) else {
-                            return;
+                        if let Some(Ok(value)) = state.zoom_input.as_ref().map(|v| v.parse()) {
+                            state.zoom = value;
                         };
-                        state.zoom = value;
                     };
                 }),
         )),

--- a/src/map/events/on_mouse_click.rs
+++ b/src/map/events/on_mouse_click.rs
@@ -1,72 +1,70 @@
-use std::{marker::PhantomData, rc::Rc};
-
-use wasm_bindgen_futures::spawn_local;
+use web_sys::wasm_bindgen::UnwrapThrowExt;
 use xilem_web::{
-    core::{MessageResult, Mut, View, ViewId, ViewMarker},
+    core::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker},
     DynMessage,
 };
 
 use crate::{MapChildElement, MapCtx};
 
-pub(crate) const fn on_mouse_click<State, F>(callback: F) -> OnMouseClick<State, F>
+pub(crate) const fn on_mouse_click<State, F>(callback: F) -> OnMouseClick<F>
 where
     F: Fn(&mut State, leaflet::MouseEvent) + 'static,
 {
-    OnMouseClick {
-        callback,
-        phantom: PhantomData,
-    }
+    OnMouseClick { callback }
 }
 
-pub struct OnMouseClick<State, F> {
+pub struct OnMouseClick<F> {
     callback: F,
-    phantom: PhantomData<fn() -> State>,
 }
 
-impl<State, F> ViewMarker for OnMouseClick<State, F> {}
-
-pub struct OnMouseClickViewState;
+impl<F> ViewMarker for OnMouseClick<F> {}
 
 #[derive(Debug)]
 struct ClickMessage(leaflet::MouseEvent);
 
-impl<State, Action, F> View<State, Action, MapCtx, DynMessage> for OnMouseClick<State, F>
+/// Distinctive ID for better debugging
+const ON_MOUSE_CLICK_ID: ViewId = ViewId::new(23668);
+
+impl<State, Action, F> View<State, Action, MapCtx, DynMessage> for OnMouseClick<F>
 where
     State: 'static,
     F: Fn(&mut State, leaflet::MouseEvent) + 'static,
 {
     type Element = MapChildElement;
 
-    type ViewState = OnMouseClickViewState;
+    type ViewState = ();
 
     fn build(&self, ctx: &mut MapCtx) -> (Self::Element, Self::ViewState) {
-        let thunk = Rc::clone(&ctx.thunk);
-        ctx.map.on_mouse_click(Box::new(move |ev| {
-            let thunk = Rc::clone(&thunk);
-            spawn_local(async move {
-                thunk.push_message(ClickMessage(ev));
-            });
-        }));
-        let view_state = OnMouseClickViewState {};
-        (MapChildElement, view_state)
+        ctx.with_id(ON_MOUSE_CLICK_ID, |ctx| {
+            let thunk = ctx.dom_ctx.message_thunk();
+            // TODO use add/remove_event_listener, for graceful lifecycle handling
+            ctx.map
+                .on_mouse_click(Box::new(move |ev| thunk.push_message(ClickMessage(ev))));
+            (MapChildElement::Event, ())
+        })
     }
 
-    fn rebuild(&self, _: &Self, _: &mut Self::ViewState, _: &mut MapCtx, _: Mut<Self::Element>) {
-        // TODO:
+    fn rebuild(&self, _: &Self, _: &mut Self::ViewState, ctx: &mut MapCtx, _: Mut<Self::Element>) {
+        ctx.with_id(ON_MOUSE_CLICK_ID, |_ctx| {
+            // TODO
+        })
     }
 
-    fn teardown(&self, _: &mut Self::ViewState, _: &mut MapCtx, _: Mut<Self::Element>) {
-        // TODO
+    fn teardown(&self, _: &mut Self::ViewState, ctx: &mut MapCtx, _: Mut<Self::Element>) {
+        ctx.with_id(ON_MOUSE_CLICK_ID, |_ctx| {
+            // TODO
+        })
     }
 
     fn message(
         &self,
         _: &mut Self::ViewState,
-        _: &[ViewId],
+        id_path: &[ViewId],
         message: DynMessage,
         state: &mut State,
     ) -> MessageResult<Action, DynMessage> {
-        let ClickMessage(ev) = *message.downcast().unwrap();
+        debug_assert!(id_path.len() == 1 && id_path[0] == ON_MOUSE_CLICK_ID);
+        let ClickMessage(ev) = *message.downcast().unwrap_throw();
         (self.callback)(state, ev);
         MessageResult::Nop
     }

--- a/src/map/events/on_zoom_end.rs
+++ b/src/map/events/on_zoom_end.rs
@@ -1,36 +1,32 @@
-use std::{marker::PhantomData, rc::Rc};
-
-use wasm_bindgen_futures::spawn_local;
 use xilem_web::{
-    core::{MessageResult, Mut, View, ViewId, ViewMarker},
+    core::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker as _},
     DynMessage,
 };
 
 use crate::{MapChildElement, MapCtx};
 
-pub(crate) const fn on_zoom_end<State, F>(callback: F) -> OnZoomEnd<State, F>
+pub const fn on_zoom_end<State, F>(callback: F) -> OnZoomEnd<F>
 where
     F: Fn(&mut State, f64) + 'static,
 {
-    OnZoomEnd {
-        callback,
-        phantom: PhantomData,
-    }
+    OnZoomEnd { callback }
 }
 
-pub struct OnZoomEnd<State, F> {
+pub struct OnZoomEnd<F> {
     callback: F,
-    phantom: PhantomData<fn() -> State>,
 }
 
-impl<State, F> ViewMarker for OnZoomEnd<State, F> {}
+impl<F> ViewMarker for OnZoomEnd<F> {}
 
 pub struct OnZoomEndViewState;
 
 #[derive(Debug)]
 struct ZoomEndMessage(f64);
 
-impl<State, Action, F> View<State, Action, MapCtx, DynMessage> for OnZoomEnd<State, F>
+/// Distinctive ID for better debugging
+const ON_ZOOM_END_ID: ViewId = ViewId::new(23668);
+
+impl<State, Action, F> View<State, Action, MapCtx, DynMessage> for OnZoomEnd<F>
 where
     State: 'static,
     Action: 'static,
@@ -41,35 +37,40 @@ where
     type ViewState = OnZoomEndViewState;
 
     fn build(&self, ctx: &mut MapCtx) -> (Self::Element, Self::ViewState) {
-        let thunk = Rc::clone(&ctx.thunk);
-        let map = ctx.map.clone();
-        ctx.map.on_zoom_end(Box::new(move |_| {
-            log::debug!("Zoom changed");
-            let zoom = map.get_zoom();
-            let thunk = Rc::clone(&thunk);
-            spawn_local(async move {
-                thunk.push_message(ZoomEndMessage(zoom));
-            });
-        }));
-        let view_state = OnZoomEndViewState { /*thunk */};
-        (MapChildElement, view_state)
+        ctx.with_id(ON_ZOOM_END_ID, |ctx| {
+            let thunk = ctx.dom_ctx.message_thunk();
+            let map = ctx.map.clone();
+            // TODO use add/remove_event_listener, for graceful lifecycle handling
+            ctx.map.on_zoom_end(Box::new(move |_| {
+                let zoom = map.get_zoom();
+                log::debug!("Zoom changed: {zoom}");
+                thunk.enqueue_message(ZoomEndMessage(zoom));
+            }));
+            let view_state = OnZoomEndViewState { /*thunk */};
+            (MapChildElement::Event, view_state)
+        })
     }
 
-    fn rebuild(&self, _: &Self, _: &mut Self::ViewState, _: &mut MapCtx, _: Mut<Self::Element>) {
-        // TODO:
+    fn rebuild(&self, _: &Self, _: &mut Self::ViewState, ctx: &mut MapCtx, _: Mut<Self::Element>) {
+        ctx.with_id(ON_ZOOM_END_ID, |_ctx| {
+            // TODO
+        })
     }
 
-    fn teardown(&self, _: &mut Self::ViewState, _: &mut MapCtx, _: Mut<Self::Element>) {
-        // TODO
+    fn teardown(&self, _: &mut Self::ViewState, ctx: &mut MapCtx, _: Mut<Self::Element>) {
+        ctx.with_id(ON_ZOOM_END_ID, |_ctx| {
+            // TODO
+        })
     }
 
     fn message(
         &self,
         _: &mut Self::ViewState,
-        _: &[ViewId],
+        id_path: &[ViewId],
         message: DynMessage,
         state: &mut State,
     ) -> MessageResult<Action, DynMessage> {
+        debug_assert!(id_path.len() == 1 && id_path[0] == ON_ZOOM_END_ID);
         let ZoomEndMessage(zoom) = *message.downcast().unwrap();
         (self.callback)(state, zoom);
         MessageResult::Nop


### PR DESCRIPTION
I was interested in this myself, I think it's now possible to make this a lot cleaner (though still quite some boilerplate...).
I did implement more functionality while skimming over the code (such as `MapChildrenSplice`, putting the state of the elements in the `View::Element` etc.).

I think a `spawn_local` to delay initiation of the map should be good enough, not necessary to send itself a message (though this is a viable pattern I think). Thus no additional view id is required.

The generic markers (like `State`) are only necessary, if an inner view is composed as well (e.g. if the tile layer would contain child views).